### PR TITLE
Swapped parameters for implode function

### DIFF
--- a/src/Middleware/TrailingSlashRedirector.php
+++ b/src/Middleware/TrailingSlashRedirector.php
@@ -38,7 +38,7 @@ class TrailingSlashRedirector implements HTTPMiddleware
         if ($request && ($request->isGET() || $request->isHEAD())) {
             // skip $ignore_paths and home (`/`)
             if ($request->getURL() == '' ||
-                preg_match('/^(' . implode($ignore_paths, '|') . ')/i', $request->getURL())
+                preg_match('/^(' . implode('|',$ignore_paths) . ')/i', $request->getURL())
             ) {
                 return $delegate($request);
             }


### PR DESCRIPTION
 implode() can, for historical reasons, accept its parameters in either order. For consistency with explode(), however, it is deprecated not to use the documented order of arguments.  Causes a deprecation message in php7.4